### PR TITLE
Disable default activity header in LiveSonner view

### DIFF
--- a/mod/livesonner/view.php
+++ b/mod/livesonner/view.php
@@ -38,6 +38,7 @@ $PAGE->set_url('/mod/livesonner/view.php', ['id' => $cm->id]);
 $PAGE->set_title(format_string($livesonner->name));
 $PAGE->set_heading(format_string($course->fullname));
 $PAGE->add_body_class('mod-livesonner');
+$PAGE->activityheader->disable();
 
 if ($action === 'join') {
     require_sesskey();


### PR DESCRIPTION
## Summary
- disable the standard Moodle activity header when rendering the LiveSonner view to avoid duplicate name and description output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd431a8cbc8328bd36175bb0f6b989